### PR TITLE
単体テスト(Update)

### DIFF
--- a/src/main/java/com/kadai10/user/controller/UserController.java
+++ b/src/main/java/com/kadai10/user/controller/UserController.java
@@ -91,7 +91,7 @@ public class UserController {
   @PatchMapping("/users/{id}")
   public ResponseEntity<UserResponse> updateUser(final @PathVariable @Valid Integer id,
       final @RequestBody UserUpdateRequest updateRequest, final UriComponentsBuilder uriBuilder) {
-    User user = userService.updateUser(id);
+    User user = userService.updateUser(id, updateRequest);
     URI location = uriBuilder.path("/users/{id}").buildAndExpand(user.getId()).toUri();
     UserResponse body = new UserResponse(user.getName() + "を更新しました");
     return ResponseEntity.created(location).body(body);

--- a/src/main/java/com/kadai10/user/controller/UserController.java
+++ b/src/main/java/com/kadai10/user/controller/UserController.java
@@ -73,7 +73,7 @@ public class UserController {
   @PostMapping("/users")
   public ResponseEntity<UserResponse> insert(final @RequestBody @Valid UserRequest userRequest,
       final UriComponentsBuilder uriBuilder) {
-    User user = userService.insert(userRequest.getName(), userRequest.getOccupation());
+    User user = userService.insert(userRequest.name(), userRequest.occupation());
     URI location = uriBuilder.path("/users/{id}").buildAndExpand(user.getId()).toUri();
     UserResponse body = new UserResponse(user.getName() + "を登録しました");
     return ResponseEntity.created(location).body(body);

--- a/src/main/java/com/kadai10/user/controller/request/UserRequest.java
+++ b/src/main/java/com/kadai10/user/controller/request/UserRequest.java
@@ -2,17 +2,12 @@ package com.kadai10.user.controller.request;
 
 /**
  * ユーザー情報のリクエストを表すクラスです. このクラスは新しいユーザーの作成や既存のユーザー情報の更新などの要求を受け取ります。
+ *
+ * @param name       ユーザーの名前を表すフィールド.
+ * @param occupation ユーザーの職業を表すフィールド.
  */
-public class UserRequest {
 
-  /**
-   * ユーザーの名前を表すフィールド.
-   */
-  private final String name;
-  /**
-   * ユーザーの職業を表すフィールド.
-   */
-  private final String occupation;
+public record UserRequest(String name, String occupation) {
 
   /**
    * UserRequest オブジェクトを生成するためのコンストラクタ.
@@ -20,26 +15,6 @@ public class UserRequest {
    * @param name       ユーザーの名前
    * @param occupation ユーザーの職業
    */
-  public UserRequest(final String name, final String occupation) {
-    this.name = name;
-    this.occupation = occupation;
-  }
-
-  /**
-   * ユーザーの名前を取得する.
-   *
-   * @return ユーザーの名前
-   */
-  public String getName() {
-    return name;
-  }
-
-  /**
-   * ユーザーの職業を取得する.
-   *
-   * @return ユーザーの職業
-   */
-  public String getOccupation() {
-    return occupation;
+  public UserRequest {
   }
 }

--- a/src/main/java/com/kadai10/user/controller/request/UserUpdateRequest.java
+++ b/src/main/java/com/kadai10/user/controller/request/UserUpdateRequest.java
@@ -11,17 +11,15 @@ import lombok.Setter;
 public class UserUpdateRequest {
 
   /**
-   * 静的な名前を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの名前を取得するメソッド. -- SETTER
-   * --ユーザーの名前を設定するメソッド.
-   */
-  @Getter
-  private static String name;
-  /**
    * 静的な職業を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの職業を取得するメソッド. -- SETTER
    * --ユーザーの職業を設定するメソッド.
    */
-  @Getter
-  private static String occupation;
+  private String occupation;
+  /**
+   * 静的な名前を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの名前を取得するメソッド. -- SETTER
+   * --ユーザーの名前を設定するメソッド.
+   */
+  private String name;
 
   /**
    * ユーザー情報を更新するためのリクエストオブジェクト.
@@ -30,25 +28,7 @@ public class UserUpdateRequest {
    * @param occupation ユーザーの新しい職業
    */
   public UserUpdateRequest(String name, String occupation) {
-    UserUpdateRequest.name = name;
-    UserUpdateRequest.occupation = occupation;
-  }
-
-  /**
-   * ユーザーの名前を設定するための静的メソッド.
-   *
-   * @param name ユーザーの新しい名前
-   */
-  public static void setName(String name) {
-    UserUpdateRequest.name = name;
-  }
-
-  /**
-   * ユーザーの職業を設定するための静的メソッド.
-   *
-   * @param occupation ユーザーの新しい職業
-   */
-  public static void setOccupation(String occupation) {
-    UserUpdateRequest.occupation = occupation;
+    this.name = name;
+    this.occupation = occupation;
   }
 }

--- a/src/main/java/com/kadai10/user/controller/request/UserUpdateRequest.java
+++ b/src/main/java/com/kadai10/user/controller/request/UserUpdateRequest.java
@@ -1,20 +1,24 @@
 package com.kadai10.user.controller.request;
 
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * ユーザー情報の更新リクエストを表すクラスです. このクラスはユーザーの名前や職業などの更新が必要な情報を受け取ります。 ユーザー情報を更新する際に使用されます。
  */
-
+@Setter
+@Getter
 public class UserUpdateRequest {
 
   /**
-   * 静的な名前を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの名前を取得するメソッド.
+   * 静的な名前を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの名前を取得するメソッド. -- SETTER
+   * --ユーザーの名前を設定するメソッド.
    */
   @Getter
   private static String name;
   /**
-   * 静的な職業を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの職業を取得するメソッド.
+   * 静的な職業を表すクラス変数. この変数はすべてのインスタンスで共有され、クラスから直接アクセス可能 -- GETTER -- ユーザーの職業を取得するメソッド. -- SETTER
+   * --ユーザーの職業を設定するメソッド.
    */
   @Getter
   private static String occupation;
@@ -22,31 +26,29 @@ public class UserUpdateRequest {
   /**
    * ユーザー情報を更新するためのリクエストオブジェクト.
    *
-   * @param newName       ユーザーの新しい名前
-   * @param newOccupation ユーザーの新しい職業
+   * @param name       ユーザーの新しい名前
+   * @param occupation ユーザーの新しい職業
    */
-  public UserUpdateRequest(String newName, String newOccupation) {
-
-    name = newName;
-    occupation = newOccupation;
+  public UserUpdateRequest(String name, String occupation) {
+    UserUpdateRequest.name = name;
+    UserUpdateRequest.occupation = occupation;
   }
 
   /**
-   * ユーザーの名前を設定するメソッド.
+   * ユーザーの名前を設定するための静的メソッド.
    *
-   * @param newName ユーザーの新しい名前
+   * @param name ユーザーの新しい名前
    */
-  public void setName(String newName) {
-    name = newName;
+  public static void setName(String name) {
+    UserUpdateRequest.name = name;
   }
 
   /**
-   * ユーザーの職業を設定するメソッド.
+   * ユーザーの職業を設定するための静的メソッド.
    *
-   * @param newOccupation ユーザーの新しい職業
+   * @param occupation ユーザーの新しい職業
    */
-
-  public void setOccupation(String newOccupation) {
-    occupation = newOccupation;
+  public static void setOccupation(String occupation) {
+    UserUpdateRequest.occupation = occupation;
   }
 }

--- a/src/main/java/com/kadai10/user/service/UserService.java
+++ b/src/main/java/com/kadai10/user/service/UserService.java
@@ -80,14 +80,14 @@ public class UserService {
    * @return 更新されたユーザー情報
    * @throws UserNotFoundException 指定されたIDのユーザーが見つからない場合
    */
-  public User updateUser(final Integer id) {
+  public User updateUser(final Integer id, UserUpdateRequest updateRequest) {
     User user = userMapper.findById(id)
         .orElseThrow(() -> new UserNotFoundException("userID:" + id + " not found"));
-    if (UserUpdateRequest.getName() != null) {
-      user.setName(UserUpdateRequest.getName());
+    if (updateRequest.getName() != null) {
+      user.setName(updateRequest.getName());
     }
-    if (UserUpdateRequest.getOccupation() != null) {
-      user.setOccupation(UserUpdateRequest.getOccupation());
+    if (updateRequest.getOccupation() != null) {
+      user.setOccupation(updateRequest.getOccupation());
     }
     userMapper.updateUser(user);
     return user;

--- a/src/test/java/com/kadai10/user/service/UserServiceTest.java
+++ b/src/test/java/com/kadai10/user/service/UserServiceTest.java
@@ -75,9 +75,7 @@ public class UserServiceTest {
   @Test
   public void 存在するユーザーの名前と職業の更新できること() {
     doReturn(Optional.of(new User(2, "北野", "介護士"))).when(userMapper).findById(2);
-    UserUpdateRequest.setName("三田");
-    UserUpdateRequest.setOccupation("消防士");
-    User actual = userService.updateUser(2);
+    User actual = userService.updateUser(2, new UserUpdateRequest("三田", "消防士"));
     User user = new User(2, "三田", "消防士");
     assertThat(actual).isEqualTo(user);
     verify(userMapper).findById(2);
@@ -87,8 +85,9 @@ public class UserServiceTest {
   @Test
   public void 存在するユーザーの名前のみ更新できること() {
     doReturn(Optional.of(new User(1, "小山", "警察官"))).when(userMapper).findById(1);
-    UserUpdateRequest.setName("小川");
-    User actual = userService.updateUser(1);
+    UserUpdateRequest updateRequest =
+        new UserUpdateRequest("小川", null);
+    User actual = userService.updateUser(1, updateRequest);
     User user = new User(1, "小川", "警察官");
     assertThat(actual).isEqualTo(user);
     verify(userMapper).findById(1);
@@ -98,8 +97,8 @@ public class UserServiceTest {
   @Test
   public void 存在するユーザーの職業のみ更新できること() {
     doReturn(Optional.of(new User(1, "小山", "警察官"))).when(userMapper).findById(1);
-    UserUpdateRequest.setOccupation("警備員");
-    User actual = userService.updateUser(1);
+    UserUpdateRequest updateRequest = new UserUpdateRequest(null, "警備員");
+    User actual = userService.updateUser(1, updateRequest);
     User user = new User(1, "小山", "警備員");
     assertThat(actual).isEqualTo(user);
     verify(userMapper).findById(1);

--- a/src/test/java/com/kadai10/user/service/UserServiceTest.java
+++ b/src/test/java/com/kadai10/user/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kadai10.user.controller.request.UserUpdateRequest;
 import com.kadai10.user.entity.User;
 import com.kadai10.user.exception.OccupationAlreadyExistsException;
 import com.kadai10.user.exception.UserNotFoundException;
@@ -65,6 +66,48 @@ public class UserServiceTest {
 
   @Test
   public void すでに存在する職業を再度登録時にエラーが返されること() {
+    when(userMapper.findByOccupation("医者")).thenReturn(Optional.of(new User(1, "田中", "医者")));
+    assertThrows(OccupationAlreadyExistsException.class, () -> {
+      userService.insert("田中", "医者");
+    });
+  }
+
+  @Test
+  public void 存在するユーザーの名前と職業の更新できること() {
+    doReturn(Optional.of(new User(2, "北野", "介護士"))).when(userMapper).findById(2);
+    UserUpdateRequest.setName("三田");
+    UserUpdateRequest.setOccupation("消防士");
+    User actual = userService.updateUser(2);
+    User user = new User(2, "三田", "消防士");
+    assertThat(actual).isEqualTo(user);
+    verify(userMapper).findById(2);
+    verify(userMapper).updateUser(user);
+  }
+
+  @Test
+  public void 存在するユーザーの名前のみ更新できること() {
+    doReturn(Optional.of(new User(1, "小山", "警察官"))).when(userMapper).findById(1);
+    UserUpdateRequest.setName("小川");
+    User actual = userService.updateUser(1);
+    User user = new User(1, "小川", "警察官");
+    assertThat(actual).isEqualTo(user);
+    verify(userMapper).findById(1);
+    verify(userMapper).updateUser(user);
+  }
+
+  @Test
+  public void 存在するユーザーの職業のみ更新できること() {
+    doReturn(Optional.of(new User(1, "小山", "警察官"))).when(userMapper).findById(1);
+    UserUpdateRequest.setOccupation("警備員");
+    User actual = userService.updateUser(1);
+    User user = new User(1, "小山", "警備員");
+    assertThat(actual).isEqualTo(user);
+    verify(userMapper).findById(1);
+    verify(userMapper).updateUser(user);
+  }
+
+  @Test
+  public void すでに存在する職業に更新時にエラーが返されること() {
     when(userMapper.findByOccupation("医者")).thenReturn(Optional.of(new User(1, "田中", "医者")));
     assertThrows(OccupationAlreadyExistsException.class, () -> {
       userService.insert("田中", "医者");


### PR DESCRIPTION
# 単体テスト(Update)実装

## 行ったテスト内容
* ### 存在するユーザーの名前と職業の更新できること
<img width="833" alt="スクリーンショット 2024-01-09 23 47 44" src="https://github.com/tomoya0844/kadai10/assets/146510558/a5c464c0-62e9-4c59-bda1-d886eb840b13">

* ### 存在するユーザーの名前のみ更新できること
<img width="914" alt="スクリーンショット 2024-01-09 23 48 10" src="https://github.com/tomoya0844/kadai10/assets/146510558/c49d65f1-b0e3-4ffc-8a69-cfd48f41f80b">

* ### 存在するユーザーの職業のみ更新できること
<img width="791" alt="スクリーンショット 2024-01-09 23 48 29" src="https://github.com/tomoya0844/kadai10/assets/146510558/396812b8-00e1-4590-be75-a5c092a9f563">

* ### すでに存在する職業に更新時にエラーが返されること
<img width="929" alt="スクリーンショット 2024-01-09 23 48 48" src="https://github.com/tomoya0844/kadai10/assets/146510558/cd62d62e-38bf-4e7b-950e-83870bf84707">
