### PR TITLE
Delete処理のDBテスト

### DIFF
--- a/src/main/java/com/kadai10/user/mapper/UserMapper.java
+++ b/src/main/java/com/kadai10/user/mapper/UserMapper.java
@@ -77,5 +77,5 @@ public interface UserMapper {
    * @param id 削除するユーザーのid
    */
   @Delete("DELETE FROM users WHERE id = #{id}")
-  void deleteUser(User id);
+  void deleteUser(int id);
 }

--- a/src/main/java/com/kadai10/user/service/UserService.java
+++ b/src/main/java/com/kadai10/user/service/UserService.java
@@ -109,7 +109,7 @@ public class UserService {
   public User deleteUser(final Integer id) {
     User user = userMapper.findById(id)
         .orElseThrow(() -> new UserNotFoundException("userID:" + id + " not found"));
-    userMapper.deleteUser(user);
+    userMapper.deleteUser(id);
     return user;
   }
 }

--- a/src/test/java/com/kadai10/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/kadai10/user/mapper/UserMapperTest.java
@@ -99,4 +99,20 @@ class UserMapperTest {
       userMapper.updateUser(user);
     });
   }
+
+  @Test
+  @DataSet(value = "datasets/users.yml")
+  @ExpectedDataSet("datasets/deleteTestUser.yml")
+  @Transactional
+  public void 存在するIDを指定して削除できること() {
+    userMapper.deleteUser(3);
+  }
+
+  @Test
+  @DataSet(value = "datasets/users.yml")
+  @ExpectedDataSet("datasets/users.yml")
+  @Transactional
+  public void 存在しないIDを指定した時にユーザーが削除されないこと() {
+    userMapper.findById(4);
+  }
 }

--- a/src/test/java/com/kadai10/user/service/UserServiceTest.java
+++ b/src/test/java/com/kadai10/user/service/UserServiceTest.java
@@ -114,7 +114,7 @@ public class UserServiceTest {
   }
 
   @Test
-  public void 存在IDを指定して削除できること() {
+  public void 存在するIDを指定して削除できること() {
     doReturn(Optional.of(new User(1, "小山", "警察官"))).when(userMapper).findById(1);
     userService.deleteUser(1);
     verify(userMapper).findById(1);

--- a/src/test/java/com/kadai10/user/service/UserServiceTest.java
+++ b/src/test/java/com/kadai10/user/service/UserServiceTest.java
@@ -112,4 +112,21 @@ public class UserServiceTest {
       userService.insert("田中", "医者");
     });
   }
+
+  @Test
+  public void 存在IDを指定して削除できること() {
+    doReturn(Optional.of(new User(1, "小山", "警察官"))).when(userMapper).findById(1);
+    userService.deleteUser(1);
+    verify(userMapper).findById(1);
+    verify(userMapper).deleteUser(1);
+  }
+
+  @Test
+  public void 存在しないIDを指定した時にエラーが返ること() {
+    doReturn(Optional.empty()).when(userMapper).findById(100);
+    assertThrows(UserNotFoundException.class, () -> {
+      userService.deleteUser(100);
+    });
+    verify(userMapper).findById(100);
+  }
 }

--- a/src/test/resources/datasets/deleteTestUser.yml
+++ b/src/test/resources/datasets/deleteTestUser.yml
@@ -1,0 +1,7 @@
+users:
+  - id: 1
+    name: "小山"
+    occupation: "警察官"
+  - id: 2
+    name: "北野"
+    occupation: "介護士"


### PR DESCRIPTION
# Delete処理のDBテスト

## 行ったテストケース
* 存在するIDを指定して削除できること
<img width="818" alt="スクリーンショット 2024-01-14 0 59 08" src="https://github.com/tomoya0844/kadai10/assets/146510558/cfdc3591-6082-4cd8-9a22-e93300cc6b40">

* 存在しないIDを指定した時にユーザーが削除されないこと
 
<img width="771" alt="スクリーンショット 2024-01-14 0 59 30" src="https://github.com/tomoya0844/kadai10/assets/146510558/ea4f4add-d59d-4e48-9305-1e0ffdf491fb">
