### PR TITLE
Delete処理のDBテスト実装

### DIFF
--- a/src/test/java/com/kadai10/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/kadai10/user/mapper/UserMapperTest.java
@@ -99,4 +99,20 @@ class UserMapperTest {
       userMapper.updateUser(user);
     });
   }
+
+  @Test
+  @DataSet(value = "datasets/users.yml")
+  @ExpectedDataSet("datasets/deleteTestUser.yml")
+  @Transactional
+  public void 存在するIDを指定して削除できること() {
+    userMapper.deleteUser(3);
+  }
+
+  @Test
+  @DataSet(value = "datasets/users.yml")
+  @ExpectedDataSet("datasets/users.yml")
+  @Transactional
+  public void 存在しないIDを指定した時にユーザーが削除されないこと() {
+    userMapper.findById(4);
+  }
 }

--- a/src/test/resources/datasets/deleteTestUser.yml
+++ b/src/test/resources/datasets/deleteTestUser.yml
@@ -1,0 +1,7 @@
+users:
+  - id: 1
+    name: "小山"
+    occupation: "警察官"
+  - id: 2
+    name: "北野"
+    occupation: "介護士"


### PR DESCRIPTION
# Delete処理のDBテスト

## 行ったテストケース
### * 存在するIDを指定して削除できること
<img width="818" alt="スクリーンショット 2024-01-14 0 59 08" src="https://github.com/tomoya0844/kadai10/assets/146510558/cfdc3591-6082-4cd8-9a22-e93300cc6b40">

### * 存在しないIDを指定した時にユーザーが削除されないこと
 
<img width="771" alt="スクリーンショット 2024-01-14 0 59 30" src="https://github.com/tomoya0844/kadai10/assets/146510558/ea4f4add-d59d-4e48-9305-1e0ffdf491fb">
